### PR TITLE
don't let tensorflow allocate all gpu memory

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true'
+
 import numpy as np
 import torch
 from keras.models import load_model


### PR DESCRIPTION
Fixed an issue where TensorFlow would allocate the entire GPU memory, which leads to a memory error in PyTorch.